### PR TITLE
Add findExpensesForCurrentYear() function to User.js

### DIFF
--- a/src/User.js
+++ b/src/User.js
@@ -7,6 +7,7 @@ class User {
     this.pastTrips = this.findPastTrips(travelData)
     this.pendingTrips = this.findPendingTrips(travelData)
     this.currentTrip = this.findCurrentTrip(travelData)
+    this.expenses = this.findExpensesForCurrentYear(travelData)
   }
 
   findUpcomingTrips(travelData) {
@@ -43,6 +44,24 @@ class User {
       let finalDayOfTrip = time.daysFromDate(departure, trip.duration)
       return trip.status === "approved" && trip.userID === this.userId ? time.isBetween(departure, today, finalDayOfTrip) : false
     })
+  }
+
+  findExpensesForCurrentYear(travelData) {
+    let future = time.daysFromDate(new Date(), 36500)
+    let spentThisYear = {};
+    spentThisYear.thisYear = new Date(new Date().getFullYear(), 0)
+    spentThisYear.tripExpenses = travelData.trips.reduce((acc, trip) => {
+      if (time.isBetween(spentThisYear.thisYear, time.buildDate(trip.date), future) && trip.status === "approved" && trip.userID === this.userId) {
+        let destination = travelData.destinations.find(place => place.id === trip.destinationID)
+        let totalForTrip = (destination.estimatedFlightCostPerPerson * trip.travelers) + (destination.estimatedLodgingCostPerDay * trip.travelers)
+        return acc + totalForTrip
+      } else {
+        return acc
+      }
+    }, 0)
+    spentThisYear.agentFees = Math.floor(spentThisYear.tripExpenses * 0.1)
+    spentThisYear.total = spentThisYear.tripExpenses + spentThisYear.agentFees
+    return [spentThisYear]
   }
 
   getUserData() {

--- a/test/User-test.js
+++ b/test/User-test.js
@@ -151,4 +151,15 @@ describe('User', () => {
       }
     ]);
   });
+
+  it('should be able to calculate how much the traveler has spent this year, including a travel aget fee of 10%', () => {
+    expect(testUser.expenses).to.deep.equal([
+      {
+        thisYear: new Date(2020, 0),
+        tripExpenses: 2040,
+        agentFees: 204,
+        total: 2244
+      }
+    ]);
+  });
 });


### PR DESCRIPTION
## Description

This PR adds the ability for the User object to (given the travelRepository object as a parameter) calculate its yearly expenses. The calculation counts only 'approved' trips, and counts all trips who's departure date is within 100 years of the current year.

## Affected areas of application

- User.js
- User-test.js

## How Has This Been Tested?

- NPM test with Chai and Mocha in conjunction with Webpack

## Relevant Tickets

- Progress towards #/3

## Notes

This might need refactoring. As it is currently, the issue might arise that a trip booked three years out would still show as an expense in 2021. There is, unfortunately, no current data regarding exactly WHEN a traveler is charged or 'approved' a trip, so I'm leaving it for now.